### PR TITLE
Muutettu chown-komennon user:group -syntaksi

### DIFF
--- a/docs/rahti/react_julkaiseminen.md
+++ b/docs/rahti/react_julkaiseminen.md
@@ -23,7 +23,7 @@ FROM nginx:alpine
 # Support running as arbitrary user which belongs to the root group
 # Note that users are not allowed to listen on privileged ports (< 1024)
 RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx && \
-    chown nginx.root /var/cache/nginx /var/run /var/log/nginx && \
+    chown nginx:root /var/cache/nginx /var/run /var/log/nginx && \
     # Make /etc/nginx/html/ available to use
     mkdir -p /etc/nginx/html/ && chmod 777 /etc/nginx/html/ && \
     # comment user directive as master process is run as user in OpenShift anyhow


### PR DESCRIPTION
Esimerkkiä seuraten `docker build` -komento johti virheeseen *"1.157 chown: unknown user nginx.root"*.

`chown`-komennossa pitäisi todennäköisesti olla kaksoispiste `nginx:root` eikä `nginx.root`.